### PR TITLE
chore: revert "feat: scim should not depend on oxcore-saml"

### DIFF
--- a/scim-server/pom.xml
+++ b/scim-server/pom.xml
@@ -77,10 +77,6 @@
                     <groupId>org.glassfish</groupId>
                     <artifactId>jakarta.faces</artifactId>
                 </exclusion>
-                <exclusion>
-                	<groupId>org.gluu</groupId>
-                	<artifactId>oxcore-saml</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
This reverts commit 2eecbb03ef1d150b225a61592d9fbb0524f6938b.